### PR TITLE
Fix Docker build for vocabulary action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@
 # these patterns additionally prune noisy/large files from the build context.
 
 .git
-.github
+# NOTE: do not exclude .github — Dockerfile COPYs .github/actions/github_action_main.py
 .claude
 .idea
 .venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@ COPY ./ETmaterials ./ETmaterials
 COPY ./instrumentAll ./instrumentAll
 COPY ./instruments ./instruments
 COPY ./docs  ./docs
-COPY ./cache ./cache
 
-# RUN chmod a+x /app/github_action_main.py
+# cache/ is not committed (gitignored); the action creates cache/ inside the
+# container via _reset_cache_db() before each vocab load.
+
 RUN chmod a+x /app/github_action_main.py
 
 # Quarto install instructions from https://www.r-bloggers.com/2022/07/how-to-set-up-quarto-with-docker-part-1-static-content/
@@ -27,7 +28,7 @@ RUN pip install -r /app/tools/requirements.txt
 RUN curl -LO https://quarto.org/download/latest/quarto-linux-amd64.deb
 RUN gdebi --non-interactive quarto-linux-amd64.deb
 
-ENV PYTHONPATH /app
+ENV PYTHONPATH=/app
 ENTRYPOINT ["/app/github_action_main.py"]
 
 # This is for debugging the Docker image build process, ensures the container stays up


### PR DESCRIPTION
## Summary

- `.dockerignore` excluded `.github`, but `Dockerfile` COPYs `.github/actions/github_action_main.py` — the build aborted on "file not found".
- `Dockerfile` had `COPY ./cache ./cache`, but `cache/` is gitignored and isn't committed. Removed — `_reset_cache_db()` creates the directory in-container before each vocab load.
- Updated `ENV PYTHONPATH` to `key=value` form (silences `LegacyKeyValueFormat` warning).

## Test plan

- [ ] Dispatch `Process geochemistry vocabularies` on master after merge — build should get past the `.github/` and `cache/` COPY steps, proceed to the pip install + Quarto download, then run the vocab-processing script.