### PR TITLE
Fix cache DB path mismatch causing empty .md and missing HTML

### DIFF
--- a/.github/actions/github_action_main.py
+++ b/.github/actions/github_action_main.py
@@ -70,11 +70,11 @@ def main():
 
         if command == "uijson":
             print("Generating uijson for inclusion in webUI build")
-            _run_uijson_in_container(os.path.join(path, inputf + ".json"), voc_uri)
+            _run_uijson_in_container(os.path.join(path, inputf + ".json"), voc_uri, cachepath)
         elif command == "docs":
             print("Generating markdown and html docs")
             md_path = os.path.join(path, inputf + ".md")
-            result = _run_docs_in_container(md_path, voc_uri)
+            result = _run_docs_in_container(md_path, voc_uri, cachepath)
             if result == 0:
                 _quarto_render_html(md_path, path)
             else:
@@ -126,9 +126,9 @@ def _run_make_in_container(target: str):
     subprocess.run(["/usr/bin/make", "-C", "/app", "-f", "/app/Makefile", target])
 
 
-def _run_uijson_in_container(output_path: str, vocab_location: str):
+def _run_uijson_in_container(output_path: str, vocab_location: str, cachepath: str):
     with open(output_path, "w") as f:
-        vocab_args = ["-s", "/app/cache/vocabularies.db", "uijson", vocab_location, "-e"]
+        vocab_args = ["-s", cachepath, "uijson", vocab_location, "-e"]
         testflag = _run_python_in_container("/app/tools/vocab.py", vocab_args, f)
         if testflag == 0:
             print(f"Run_uijson: Successfully wrote uijson file to {output_path}")
@@ -137,9 +137,9 @@ def _run_uijson_in_container(output_path: str, vocab_location: str):
         return 1
 
 
-def _run_docs_in_container(output_path: str, vocab_location: str):
+def _run_docs_in_container(output_path: str, vocab_location: str, cachepath: str):
     with open(output_path, "w") as f:
-        docs_args = ["/app/cache/vocabularies.db", vocab_location]
+        docs_args = [cachepath, vocab_location]
         testflag = _run_python_in_container("/app/tools/vocab2mdCacheV2.py", docs_args, f)
         if testflag == 0:
             print(f"Docs in container: Successfully wrote doc file {vocab_location} to {output_path}")


### PR DESCRIPTION
## Root cause

GitHub Actions Docker actions run with \`--workdir /github/workspace\`, which overrides the Dockerfile's \`WORKDIR /app\`. The load step used the relative path \`cache/vocabularies.db\` (resolving to \`/github/workspace/cache/vocabularies.db\`), but the docs and uijson helpers hardcoded \`/app/cache/vocabularies.db\`. Load wrote to one path, docs read from another, and the docs subprocess failed with \`sqlite3.OperationalError: unable to open database file\`.

Run 24847657354 finished with status \`success\` because \`_run_docs_in_container\` swallows the failure ("problem with X, don't call quarto") and continues. But the uploaded output was just the empty \`.md\` files quarto never touched, which is why the 404 happened on \`https://amds-ldeo.github.io/Vocabulary/geochemistry/...html\` — no HTML was deployed.

The upstream vocabularyTemplate has the same bug; it's hidden because that template commits \`cache/\` back to \`main\` after each run, so \`/app/cache/vocabularies.db\` exists at build time from the previous run's deploy (stale, one run behind). This repo does not commit \`cache/\`, so \`/app/cache/\` is empty.

## Fix

Pass \`cachepath\` through to \`_run_docs_in_container\` and \`_run_uijson_in_container\` instead of hardcoding \`/app/cache/vocabularies.db\`. All three steps (load, docs, uijson) now agree on \`cache/vocabularies.db\` relative to the workspace CWD.

## Test plan

- [ ] Re-dispatch \`Process geochemistry vocabularies\` on master after merge.
- [ ] Verify \`gh-pages\` branch contains \`docs/geochemistry/*.html\` and \`docs/geochemistry/*_files/\` (not just \`.md\`).
- [ ] Visit \`https://amds-ldeo.github.io/Vocabulary/geochemistry/GeochemAnalyticalMethod.html\` — should render.