### PR TITLE
Reown docs/ after Docker action to fix mv permission error

### DIFF
--- a/.github/workflows/process_geochemistry_vocab.yml
+++ b/.github/workflows/process_geochemistry_vocab.yml
@@ -26,9 +26,11 @@ jobs:
 
       - name: Stage geochemistry output under docs/geochemistry
         run: |
+          # The vocabulary action runs as root in its container; its outputs in
+          # docs/ are root-owned. Re-own to the runner user so subsequent steps
+          # (mv here, JamesIves deploy action) can touch them without sudo.
+          sudo chown -R "$(id -u):$(id -g)" docs
           mkdir -p staged_docs/geochemistry
-          # Move the generated markdown/html/_files into a subdir-scoped folder
-          # so each workflow deploys to its own slice of gh-pages/docs.
           shopt -s nullglob
           for f in docs/GeochemAnalyticalMethod* docs/onegctechniquesastromatv4*; do
             mv "$f" staged_docs/geochemistry/


### PR DESCRIPTION
## Problem

The vocabulary Docker action runs as root inside its container; outputs it writes to \`docs/*\` on the runner host end up root-owned. The subsequent \`Stage geochemistry output\` step runs as the runner user and failed with:

\`\`\`
mv: cannot move 'docs/GeochemAnalyticalMethod_files' to 'staged_docs/geochemistry/GeochemAnalyticalMethod_files': Permission denied
\`\`\`

## Fix

\`sudo chown -R\` docs/ to the current runner user at the top of the staging step. Sudo is passwordless on ubuntu-latest. After the chown, the existing \`mv\` loop and the JamesIves deploy action can operate without privilege.

Will replicate this pattern in the per-subdirectory workflows for ETmaterials / instrumentAll / instruments.

## Test plan

- [ ] Re-dispatch Process geochemistry vocabularies on master after merge; should complete all steps and deploy HTML to gh-pages/docs/geochemistry/.