### PR TITLE
Add instrumentAll workflow for 7 vocabularies

### DIFF
--- a/.github/workflows/process_instrumentall_vocab.yml
+++ b/.github/workflows/process_instrumentall_vocab.yml
@@ -1,0 +1,52 @@
+# Processes the 7 SKOS vocabularies under /instrumentAll and publishes the
+# generated HTML (flat) to the gh-pages branch under /docs/instrumentAll/.
+#
+# Triggered manually via the GitHub Actions "Run workflow" button.
+#
+# Each ttl file contains several skos:ConceptScheme declarations (external
+# NERC schemes + in-house ones). The primary scheme chosen per file is the
+# one whose skos:hasTopConcept entries are anchored in the file's own
+# skos:broader/narrower graph:
+#   - SDNDEV/current  for six of the seven files
+#   - EDMED_DCAT_THEMES/current  for Parameters.ttl
+# (See PR #13 for analysis and rationale.)
+
+name: Process instrumentAll vocabularies
+on: [workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Vocabulary action (instrumentAll)
+        uses: ./
+        with:
+          action: docs
+          path: ${{ github.workspace }}
+          vocabdir: instrumentAll
+          inputttl: Instruments|NumericModel|Parameters|PositioningSystem|SampleCollection|SamplePreparation|SeismicSource
+          inputvocaburi: sdndev:current|sdndev:current|edmedscheme:current|sdndev:current|sdndev:current|sdndev:current|sdndev:current
+
+      - name: Stage instrumentAll output under docs/instrumentAll
+        run: |
+          # Action runs as root in its container; reown outputs to the runner user.
+          sudo chown -R "$(id -u):$(id -g)" docs
+          mkdir -p staged_docs/instrumentAll
+          shopt -s nullglob
+          for slug in Instruments NumericModel Parameters PositioningSystem SampleCollection SamplePreparation SeismicSource; do
+            for f in docs/${slug}.md docs/${slug}.html "docs/${slug}_files"; do
+              if [ -e "$f" ]; then
+                mv "$f" staged_docs/instrumentAll/
+              fi
+            done
+          done
+          ls -la staged_docs/instrumentAll/
+
+      - name: Deploy instrumentAll docs to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: staged_docs/instrumentAll
+          target-folder: docs/instrumentAll
+          commit-message: "Rebuild instrumentAll vocabulary HTML"

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -28,11 +28,46 @@ Vocabulary to classify types of meteorites and other extraterrestrial materials.
 
 ## Instruments and related vocabularies
 
-Concept schemes describing instrument and sample-handling categories: `Instruments`, `NumericModel`, `Parameters`, `PositioningSystem`, `SampleCollection`, `SamplePreparation`, `SeismicSource`, and `mmisw-models`.
+Concept schemes describing instrument, sampling, and parameter categories compiled from the SeaDataNet/NETMAR/NERC thesauri (SDN devices L22, SDN keyword types L19, SDN keyword categories L21, EDMED DCAT themes D01, etc.). Each file's HTML is rendered by anchoring the tree at the scheme whose `skos:hasTopConcept` entries line up with the file's actual `skos:broader`/`narrower` roots — `SDNDEV/current` for six of the seven, `EDMED_DCAT_THEMES/current` for `Parameters`.
 
-- _HTML views — pending. The `instrumentAll/*.ttl` files declare multiple ConceptSchemes per file (mix of external NERC schemes and several in-house schemes) and need a per-file "primary scheme" decision before they can be processed. `instruments/mmisw-models.ttl` needs its items retyped as `skos:Concept` before HTML generation can produce non-empty output._
-- [SKOS Turtle sources (instrumentAll)](https://github.com/amds-ldeo/Vocabulary/tree/master/instrumentAll)
-- [SKOS Turtle source (mmisw-models)](https://github.com/amds-ldeo/Vocabulary/blob/master/instruments/mmisw-models.ttl)
+### Measurement instruments
+
+- [HTML view](instrumentAll/Instruments.html)
+- [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/Instruments.ttl)
+
+### Numeric models
+
+- [HTML view](instrumentAll/NumericModel.html)
+- [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/NumericModel.ttl)
+
+### Parameters
+
+- [HTML view](instrumentAll/Parameters.html)
+- [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/Parameters.ttl)
+
+### Positioning systems
+
+- [HTML view](instrumentAll/PositioningSystem.html)
+- [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/PositioningSystem.ttl)
+
+### Sample collection instruments
+
+- [HTML view](instrumentAll/SampleCollection.html)
+- [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/SampleCollection.ttl)
+
+### Sample preparation instruments
+
+- [HTML view](instrumentAll/SamplePreparation.html)
+- [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/SamplePreparation.ttl)
+
+### Seismic sources
+
+- [HTML view](instrumentAll/SeismicSource.html)
+- [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/SeismicSource.ttl)
+
+### MMISW instrument models (pending)
+
+`instruments/mmisw-models.ttl` items use a bespoke `:ModelName` type rather than `skos:Concept`, so the markdown generator finds no concepts to render. HTML generation is deferred pending either retyping the items or extending the generator to follow `rdfs:subClassOf skos:Concept`. [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/instruments/mmisw-models.ttl).
 
 ## Related
 

--- a/instrumentAll/Instruments.ttl
+++ b/instrumentAll/Instruments.ttl
@@ -14,6 +14,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdev: <http://vocab.nerc.ac.uk/collection/L05/current/> .
 @prefix sdnc: <http://vocab.nerc.ac.uk/collection/L21/current/> .
+@prefix sdndev: <http://vocab.nerc.ac.uk/scheme/SDNDEV/> .
 @prefix sdnd: <http://vocab.nerc.ac.uk/collection/C77/current/> .
 @prefix sdnk: <http://vocab.nerc.ac.uk/collection/L19/current/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .

--- a/instrumentAll/NumericModel.ttl
+++ b/instrumentAll/NumericModel.ttl
@@ -14,6 +14,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdev: <http://vocab.nerc.ac.uk/collection/L05/current/> .
 @prefix sdnc: <http://vocab.nerc.ac.uk/collection/L21/current/> .
+@prefix sdndev: <http://vocab.nerc.ac.uk/scheme/SDNDEV/> .
 @prefix sdnd: <http://vocab.nerc.ac.uk/collection/C77/current/> .
 @prefix sdnk: <http://vocab.nerc.ac.uk/collection/L19/current/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -838,6 +839,8 @@ inst:seavoxdevicecatalog
   dcterm:title "SeaDataNet Device Thesaurus" ;
   owl:versionInfo "541" ;
   skos:altLabel "Devices" ;
+  skos:hasTopConcept sdnc:ICAT08 ;
+  skos:historyNote "2026-04-23 SMR: added skos:hasTopConcept sdnc:ICAT08 so that the vocabularyTemplate-based HTML generation can anchor the broader/narrower tree at the numeric-model category root. The base SDNDEV scheme as distributed by NERC does not list ICAT08 as a top concept; this local NumericModel.ttl export extends it solely for documentation-rendering purposes."@en ;
   skos:prefLabel "SeaDataNet Device Thesaurus" ;
 .
 <http://w3id.org/def/nerc/discipline-P08/collection>

--- a/instrumentAll/PositioningSystem.ttl
+++ b/instrumentAll/PositioningSystem.ttl
@@ -14,6 +14,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdev: <http://vocab.nerc.ac.uk/collection/L05/current/> .
 @prefix sdnc: <http://vocab.nerc.ac.uk/collection/L21/current/> .
+@prefix sdndev: <http://vocab.nerc.ac.uk/scheme/SDNDEV/> .
 @prefix sdnd: <http://vocab.nerc.ac.uk/collection/C77/current/> .
 @prefix sdnk: <http://vocab.nerc.ac.uk/collection/L19/current/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .

--- a/instrumentAll/SampleCollection.ttl
+++ b/instrumentAll/SampleCollection.ttl
@@ -14,6 +14,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdev: <http://vocab.nerc.ac.uk/collection/L05/current/> .
 @prefix sdnc: <http://vocab.nerc.ac.uk/collection/L21/current/> .
+@prefix sdndev: <http://vocab.nerc.ac.uk/scheme/SDNDEV/> .
 @prefix sdnd: <http://vocab.nerc.ac.uk/collection/C77/current/> .
 @prefix sdnk: <http://vocab.nerc.ac.uk/collection/L19/current/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .

--- a/instrumentAll/SamplePreparation.ttl
+++ b/instrumentAll/SamplePreparation.ttl
@@ -14,6 +14,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdev: <http://vocab.nerc.ac.uk/collection/L05/current/> .
 @prefix sdnc: <http://vocab.nerc.ac.uk/collection/L21/current/> .
+@prefix sdndev: <http://vocab.nerc.ac.uk/scheme/SDNDEV/> .
 @prefix sdnd: <http://vocab.nerc.ac.uk/collection/C77/current/> .
 @prefix sdnk: <http://vocab.nerc.ac.uk/collection/L19/current/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .

--- a/instrumentAll/SeismicSource.ttl
+++ b/instrumentAll/SeismicSource.ttl
@@ -14,6 +14,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdev: <http://vocab.nerc.ac.uk/collection/L05/current/> .
 @prefix sdnc: <http://vocab.nerc.ac.uk/collection/L21/current/> .
+@prefix sdndev: <http://vocab.nerc.ac.uk/scheme/SDNDEV/> .
 @prefix sdnd: <http://vocab.nerc.ac.uk/collection/C77/current/> .
 @prefix sdnk: <http://vocab.nerc.ac.uk/collection/L19/current/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .


### PR DESCRIPTION
## Summary

Wires up HTML generation for all seven \`instrumentAll/*.ttl\` files. Each ttl is anchored at the ConceptScheme whose \`skos:hasTopConcept\` entries match concepts that are actually roots of the file's \`skos:broader\`/\`narrower\` tree:

| File | Scheme | Anchored top(s) | Local md lines / headings |
|------|--------|-----------------|---------------------------|
| Instruments.ttl | SDNDEV/current | sdnc:ICAT03, ICAT04, ICAT05 | 6388 / 295 |
| NumericModel.ttl | SDNDEV/current | sdnc:ICAT08 (added, see below) | 134 / 10 |
| Parameters.ttl | EDMED_DCAT_THEMES/current | edct:D0100001..005 | 5349 / 325 |
| PositioningSystem.ttl | SDNDEV/current | sdnc:ICAT06 | 2772 / 150 |
| SampleCollection.ttl | SDNDEV/current | sdnc:ICAT01 | 7636 / 453 |
| SamplePreparation.ttl | SDNDEV/current | sdnc:ICAT02 | 182 / 13 |
| SeismicSource.ttl | SDNDEV/current | sdnc:ICAT07 | 309 / 22 |

## Source-file edits

- **New prefix bindings** — \`@prefix sdndev: <.../scheme/SDNDEV/>\` on six files; \`@prefix edmedscheme: <.../scheme/EDMED_DCAT_THEMES/>\` on \`Parameters.ttl\`. (The existing \`edct:\` prefix on Parameters points to the D01 *collection* namespace, which is a different URI — a fresh prefix avoids collision.)
- **\`NumericModel.ttl\`** — added \`skos:hasTopConcept sdnc:ICAT08\` to the in-file SDNDEV scheme block, plus \`skos:historyNote\` documenting why. \`sdnc:ICAT08\` is the only concept with \`skos:narrower\` but no \`skos:broader\` in that file, i.e. the actual tree root; no scheme currently lists it under \`hasTopConcept\`. This local extension does not alter the upstream SDNDEV content.

## Workflow

\`process_instrumentall_vocab.yml\` builds all seven in one run (pipe-delimited \`inputttl\`/\`inputvocaburi\`) and deploys flat to \`gh-pages:/docs/instrumentAll/\` — one \`<slug>.html\` per vocab, no per-file subdirectory. Follows the sudo-chown + stage + JamesIves deploy pattern already in use for geochemistry and ETmaterials.

## docs/readme.md

Replaced the "pending" block with a section per vocabulary and live links. Retained the \`mmisw-models\` note (still deferred pending item retyping).

## Test plan

- [x] Local Option-A verified for all 7 files (\`load\` + \`vocab2mdCacheV2\` exit 0; output non-trivial).
- [ ] After merge, dispatch \`Process instrumentAll vocabularies\` on master.
- [ ] Verify each landing-page link resolves at \`https://amds-ldeo.github.io/Vocabulary/instrumentAll/<slug>.html\`.