### PR TITLE
Add instruments workflow; extend getVocabRoot for flat + subclass-typed vocabs

### DIFF
--- a/.github/workflows/process_instruments_vocab.yml
+++ b/.github/workflows/process_instruments_vocab.yml
@@ -1,0 +1,45 @@
+# Processes the SKOS vocabularies under /instruments and publishes the
+# generated HTML to the gh-pages branch under /docs/instruments.
+#
+# Triggered manually via the GitHub Actions "Run workflow" button.
+#
+# mmisw-models.ttl items are typed with the bespoke :ModelName class,
+# which declares rdfs:subClassOf skos:Concept. They also lack
+# skos:hasTopConcept/topConceptOf assertions. vocab2mdCacheV2.getVocabRoot
+# falls back to listing every skos:inScheme concept as a flat root when
+# no top concepts are declared, and the fallback honors subclass typing.
+
+name: Process instruments vocabularies
+on: [workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Vocabulary action (instruments)
+        uses: ./
+        with:
+          action: docs
+          path: ${{ github.workspace }}
+          vocabdir: instruments
+          inputttl: mmisw-models
+          inputvocaburi: mmiscm:ontology
+
+      - name: Stage instruments output under docs/instruments
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" docs
+          mkdir -p staged_docs/instruments
+          shopt -s nullglob
+          for f in docs/mmisw-models*; do
+            mv "$f" staged_docs/instruments/
+          done
+          ls -la staged_docs/instruments/
+
+      - name: Deploy instruments docs to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: staged_docs/instruments
+          target-folder: docs/instruments
+          commit-message: "Rebuild instruments vocabulary HTML"

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -65,9 +65,10 @@ Concept schemes describing instrument, sampling, and parameter categories compil
 - [HTML view](instrumentAll/SeismicSource.html)
 - [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/SeismicSource.ttl)
 
-### MMISW instrument models (pending)
+### MMISW instrument models
 
-`instruments/mmisw-models.ttl` items use a bespoke `:ModelName` type rather than `skos:Concept`, so the markdown generator finds no concepts to render. HTML generation is deferred pending either retyping the items or extending the generator to follow `rdfs:subClassOf skos:Concept`. [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/instruments/mmisw-models.ttl).
+- [HTML view](instruments/mmisw-models.html)
+- [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/instruments/mmisw-models.ttl)
 
 ## Related
 

--- a/instruments/mmisw-models.ttl
+++ b/instruments/mmisw-models.ttl
@@ -4,6 +4,7 @@
 @prefix : <http://mmisw.org/ont/trdi/models/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dcterm: <http://purl.org/dc/terms/> .
+@prefix mmiscm: <http://w3id.org/def/mmisw/models/> .
 @prefix omv: <http://omv.ontoware.org/2005/05/ontology#> .
 @prefix omvmmi: <http://mmisw.org/ont/mmi/20081020/ontologyMetadata/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/tools/vocab2mdCacheV2.py
+++ b/tools/vocab2mdCacheV2.py
@@ -132,6 +132,13 @@ def getVocabRoot(g, v):
     Accepts both concept->scheme (``skos:topConceptOf``) and
     scheme->concept (``skos:hasTopConcept``) assertions, since SKOS
     vocabularies in the wild use either (or both).
+
+    If neither assertion appears, falls back to every concept in the
+    scheme treated as a flat root. The fallback honors both direct
+    ``rdf:type skos:Concept`` and subclass typings (``rdf:type ?C`` where
+    ``?C rdfs:subClassOf skos:Concept``) — the latter is needed for
+    vocabularies like MMISW whose items are typed with a bespoke class
+    that declares ``rdfs:subClassOf skos:Concept``.
     """
     q = PFX + """SELECT DISTINCT ?s WHERE {
         { ?s skos:topConceptOf ?vocabulary . }
@@ -139,10 +146,21 @@ def getVocabRoot(g, v):
         { ?vocabulary skos:hasTopConcept ?s . }
     }"""
     qres = g.query(q, initBindings={'vocabulary': v})
-    res = []
-    for row in qres:
-        res.append(row[0])
-    return res
+    res = [row[0] for row in qres]
+    if res:
+        return res
+
+    q = PFX + """SELECT DISTINCT ?s WHERE {
+        ?s skos:inScheme ?vocabulary .
+        {
+            ?s rdf:type skos:Concept .
+        } UNION {
+            ?s rdf:type ?cls .
+            ?cls rdfs:subClassOf skos:Concept .
+        }
+    }"""
+    qres = g.query(q, initBindings={'vocabulary': v})
+    return [row[0] for row in qres]
 
 def getNarrower(g, v, r):
     """Return concepts that are skos:broader of r.


### PR DESCRIPTION
## Summary

Wires up HTML generation for \`instruments/mmisw-models.ttl\` and makes the tool tolerant of two previously-unhandled ttl shapes:

1. Items typed with a bespoke class that declares \`rdfs:subClassOf skos:Concept\` (rather than \`rdf:type skos:Concept\` directly).
2. Vocabularies with no \`skos:hasTopConcept\` / \`skos:topConceptOf\` assertions at all — effectively flat concept lists.

Both apply to \`mmisw-models.ttl\`: 14 items are typed \`:ModelName\` (with \`:ModelName rdfs:subClassOf skos:Concept\` declared in-file), and no top concepts are listed anywhere.

## Tool change

\`tools/vocab2mdCacheV2.py::getVocabRoot\` now falls through to a second query when the \`topConceptOf\`/\`hasTopConcept\` lookup returns empty:

\`\`\`sparql
SELECT DISTINCT ?s WHERE {
    ?s skos:inScheme ?vocabulary .
    { ?s rdf:type skos:Concept . }
    UNION
    { ?s rdf:type ?cls . ?cls rdfs:subClassOf skos:Concept . }
}
\`\`\`

Every scheme member becomes a flat root; \`describeNarrowerTerms\` returns nothing for items with no \`broader\`/\`narrower\`, so the output is a flat list.

The change is a local divergence from \`isamplesorg/vocabularyTemplate\` — worth contributing upstream eventually.

## Source

- \`instruments/mmisw-models.ttl\` — added \`@prefix mmiscm: <http://w3id.org/def/mmisw/models/>\` so the workflow can pass \`mmiscm:ontology\`.

## Workflow

- \`process_instruments_vocab.yml\`: manual dispatch; deploys to \`gh-pages:/docs/instruments/\` (flat).
- \`docs/readme.md\`: pending note replaced with live link.

## Test plan

- [x] Local Option-A run: 189-line md, 15 headings (14 model items + scheme title). All \`:ModelName\` instances render as concepts.
- [ ] After merge, dispatch \`Process instruments vocabularies\`; verify HTML lands at \`https://amds-ldeo.github.io/Vocabulary/instruments/mmisw-models.html\`.

## Minor cosmetic note

The generated page title is "ConceptScheme" (the fallback label) because \`<http://w3id.org/def/mmisw/models/ontology>\` has no \`skos:prefLabel\` in the source. Not fixed here — adding a prefLabel is a future source edit.