### PR TITLE
Rewrite README, add AGENTS.md for post-port repo state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,107 @@
+# AGENTS.md
+
+Short operational guide for maintainers and coding agents working on this repo. See [`README.md`](README.md) for the user-facing overview.
+
+## What this repo is
+
+A multi-subdirectory SKOS vocabulary repo adapted from [`isamplesorg/vocabularyTemplate`](https://github.com/isamplesorg/vocabularyTemplate). Pipeline: SKOS Turtle (`<subdir>/*.ttl`) → SQLite (`tools/vocab.py` / navocab) → Markdown (`tools/vocab2mdCacheV2.py`) → HTML (Quarto) → deployed to `gh-pages:/docs/<subdir>/` via [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action).
+
+Unlike the upstream template (which assumes a single `vocabulary/` folder), this repo runs one workflow per subdirectory and passes the target directory through the `vocabdir` input on [`action.yml`](action.yml). Docs landing page lives at [`docs/readme.md`](docs/readme.md) and is deployed by a dedicated [`publish_landing_page.yml`](.github/workflows/publish_landing_page.yml) with `clean: false` so per-subdir content isn't wiped.
+
+Live site: <https://amds-ldeo.github.io/Vocabulary/>.
+
+## Vocabularies
+
+| Subdir | Slug (no ext) | ConceptScheme CURIE | Notes |
+|---|---|---|---|
+| `geochemistry` | `GeochemAnalyticalMethod` | `meth:method` | `meth:` = `<https://w3id.org/geochem/1.0/analyticalmethod/>` |
+| `geochemistry` | `onegctechniquesastromatv4` | `meth:method` | `meth:` = `<https://w3id.org/geochem/1.1/analyticalmethod/>` (added at top of file) |
+| `ETmaterials` | `ExtraterrestrialMaterialsMindat` | `etma:cscheme` | — |
+| `instrumentAll` | `Instruments` | `sdndev:current` | anchored at `sdnc:ICAT03`/`ICAT04`/`ICAT05` |
+| `instrumentAll` | `NumericModel` | `sdndev:current` | `skos:hasTopConcept sdnc:ICAT08` added locally (see `skos:historyNote`) |
+| `instrumentAll` | `Parameters` | `edmedscheme:current` | anchored at `edct:D0100001..005` |
+| `instrumentAll` | `PositioningSystem` | `sdndev:current` | anchored at `sdnc:ICAT06` |
+| `instrumentAll` | `SampleCollection` | `sdndev:current` | anchored at `sdnc:ICAT01` |
+| `instrumentAll` | `SamplePreparation` | `sdndev:current` | anchored at `sdnc:ICAT02` |
+| `instrumentAll` | `SeismicSource` | `sdndev:current` | anchored at `sdnc:ICAT07` |
+| `instruments` | `mmisw-models` | `mmiscm:ontology` | flat vocab; items typed `:ModelName` (subclass of `skos:Concept`) — relies on local `getVocabRoot` flat+subclass fallback |
+
+`sdndev:` = `<http://vocab.nerc.ac.uk/scheme/SDNDEV/>`, `edmedscheme:` = `<http://vocab.nerc.ac.uk/scheme/EDMED_DCAT_THEMES/>`, `mmiscm:` = `<http://w3id.org/def/mmisw/models/>`. All three were added as `@prefix` declarations at the top of the relevant ttl files so the CURIEs pass through `inputvocaburi`.
+
+`instruments/gcmd-instrument.ttl` is intentionally excluded from the pipeline.
+
+## Adding a new vocabulary
+
+1. Drop the `.ttl` under the appropriate subdirectory (`geochemistry/`, `ETmaterials/`, etc.), or create a new subdir if it's a new topic.
+2. Verify the file declares a `skos:ConceptScheme` and either (a) has `skos:hasTopConcept`/`skos:topConceptOf` assertions pointing to real tree roots, or (b) is a flat list (`getVocabRoot` will fall back).
+3. Identify the `@prefix` that resolves the scheme URI as a CURIE; add one if missing (a `@prefix` line in the ttl header is a harmless binding, not a semantic change).
+4. Add the slug + CURIE to the corresponding `.github/workflows/process_<subdir>_vocab.yml` (`inputttl` and `inputvocaburi` are pipe-delimited, same order).
+5. Add a link in [`docs/readme.md`](docs/readme.md).
+6. If it's in a new subdir: create a new workflow file (copy one of the existing ones, adjust `vocabdir`, `inputttl`, `inputvocaburi`, target folder), and add `COPY ./<subdir> ./<subdir>` to the [`Dockerfile`](Dockerfile) so the source is available in the container.
+7. Verify locally with Option-A (below). On GitHub, dispatch the workflow via the Actions tab.
+
+## Local verification (Option A — no Docker)
+
+Fast feedback loop. Exercises every pure-Python fix but not the Dockerfile or the JamesIves deploy step.
+
+```bash
+python -m venv .venv
+.venv/Scripts/python.exe -m pip install -r tools/requirements.txt
+
+# Replace V (slug without .ttl) and U (ConceptScheme CURIE), per the table above.
+# Run each vocab in its own cache for isolation.
+V=GeochemAnalyticalMethod
+U=meth:method
+SUBDIR=geochemistry
+mkdir -p testoutput/local_run
+rm -f cache/vocabularies.db
+.venv/Scripts/python.exe tools/vocab.py --verbosity ERROR -s cache/vocabularies.db load "$SUBDIR/$V.ttl" "$U"
+PYTHONIOENCODING=utf-8 .venv/Scripts/python.exe tools/vocab2mdCacheV2.py cache/vocabularies.db "$U" > "testoutput/local_run/$V.md"
+quarto render "testoutput/local_run/$V.md" -t html
+```
+
+`PYTHONIOENCODING=utf-8` is a Windows-only workaround (cp1252 stdout can't encode e.g. `≥`). The Ubuntu runner uses UTF-8 by default.
+
+**Expected stderr:** one `pkg_resources is deprecated` warning from `rdflib_sqlalchemy` — mitigated but not eliminated by the `setuptools<81` pin. Anything else probably matters.
+
+**Sanity check:** `grep -c "^## " testoutput/local_run/$V.md` — should be ≥ 1 (number of top-level concept-scheme sections). Empty output means `getVocabRoot` returned nothing.
+
+## Docker verification (Option B — matches the deployed action)
+
+```bash
+docker build -t astromat-vocab .
+# Example: run the geochemistry workflow's action step locally
+docker run --rm \
+  -e INPUT_ACTION=docs \
+  -e INPUT_PATH=/app \
+  -e INPUT_VOCABDIR=geochemistry \
+  -e INPUT_INPUTTTL='GeochemAnalyticalMethod|onegctechniquesastromatv4' \
+  -e INPUT_INPUTVOCABURI='meth:method|meth:method' \
+  -v "/$(pwd)/docs://app/docs" \
+  astromat-vocab
+```
+
+The `//` prefix on the volume path is a Git-Bash-on-Windows workaround; drop it on Linux/macOS. Output is root-owned (the container runs as root); the actual workflow [`sudo chown`s `docs/`](.github/workflows/process_geochemistry_vocab.yml) before staging.
+
+## Divergences from upstream `vocabularyTemplate`
+
+The [2026-04-23 upstream PR](https://github.com/isamplesorg/vocabularyTemplate/pull/3) back-ported most generally-applicable fixes; the items below are Astromat-specific and intentionally not in the template:
+
+1. **Multi-subdirectory layout.** `Dockerfile` COPYs each vocab subdir (`./geochemistry`, `./ETmaterials`, `./instrumentAll`, `./instruments`) instead of a single `./vocabulary`. New subdirs need a matching `COPY` line.
+2. **`cache/` is gitignored and not committed.** `Dockerfile` has no `COPY ./cache ./cache`; `_reset_cache_db` in `github_action_main.py` creates the directory inside the container at runtime. The upstream template still commits `cache/` back to main after each run (stale DB from the previous run gets COPY'd at build time) — we don't.
+3. **`.dockerignore` with `.github` exception.** Excludes `**/html`, `**/archive`, spreadsheets, PDFs, etc. from the build context. Do **not** add `.github` to the ignore list — `Dockerfile` needs to COPY `.github/actions/github_action_main.py`.
+4. **Per-subdir workflow files** (one per subdirectory) rather than one `process_vocab.yml`. The `vocabdir` input (which we also contributed to the upstream template in PR #3) selects the target at dispatch time.
+5. **Landing-page workflow** [`publish_landing_page.yml`](.github/workflows/publish_landing_page.yml) with `clean: false` — owns `docs/readme.md` on `gh-pages` without wiping per-subdir content deployed by the other workflows.
+6. **`root`-owned output handling.** Each per-subdir workflow runs `sudo chown -R` over `docs/` before its own staging step (the action container runs as root, the runner steps as the non-root runner user).
+
+## Things not to touch
+
+- `.claude/` — Claude Code session/agent state. Excluded from git and Docker.
+- `.idea/` and `*.project` — JetBrains / Eclipse IDE state if they appear in the working tree; pre-existing and not yours to commit.
+- Files tagged `-SMR-Samsung.*` or similar host-tagged names — owner's local experiments on another machine.
+- Pre-existing staged/pending deletions and untracked files you didn't introduce — leave for the owner to commit separately (see `feedback_do_not_stage_in_progress` memory entry).
+
+## Known gaps
+
+- `<http://w3id.org/def/mmisw/models/ontology>` in `instruments/mmisw-models.ttl` has no `skos:prefLabel`, so the generated landing-page title for that vocab is the fallback "ConceptScheme" rather than something descriptive. Cosmetic only; fix by adding one line to the scheme block.
+- The Windows cp1252 stdout encoding trips the local Option-A `vocab2mdCacheV2.py` on files containing characters like `≥`. Workaround is `PYTHONIOENCODING=utf-8`. Not a problem on the Linux runner.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,66 @@
+# Astromat Vocabulary
 
+Workspace for developing and maintaining SKOS vocabularies that support interoperable sample-based analytical data from astromaterials. This README is the `master`-branch source reference; generated HTML views are published on the `gh-pages` branch and served at **<https://amds-ldeo.github.io/Vocabulary/>** (landing page: [`docs/readme.md`](docs/readme.md)).
 
-# What is here:
-This repository is a workspace for developing and maintaining vocabularies to support interoperable sample-based analytical data from astromaterials. 
+## Pipeline
 
-## Geochemistry folder
-Vocabularies for for analytical techniques in geochemistry and cosmochemistry.  The directory contains SKOS vocabulary drafts, serialized using turtle (ttl). HTML versions are generated in the *html* folders in this repo using the scripts in the *scripts* folder on the pages branch.  The html is accessible on the github.io pages for the repo, links included in vocabulary descriptions.
+This repo descends from [`isamplesorg/vocabularyTemplate`](https://github.com/isamplesorg/vocabularyTemplate). SKOS Turtle files under per-topic subdirectories are processed by a Docker-based GitHub Action (Turtle → SQLite via `tools/vocab.py` → Markdown via `tools/vocab2mdCacheV2.py` → HTML via Quarto) and deployed to `gh-pages:/docs/<subdir>/`. One workflow per subdirectory:
 
-### Analytical methods for geochemistry and cosmochemistry
-Vocabulary of analytical techniques for analyzing Earth,  astronomic, and planetary materials. 
-- [HTML view of Geochemical analytical methods vocabulary]( https://amds-ldeo.github.io/Vocabulary/geochemistry/html/GeochemAnalyticalMethod.html)
-- Research Vocabularies Australia vocabulary service to access vocabulary; [landing page](https://vocabs.ardc.edu.au/viewById/650)
-- SKOS vocabulary, serialized using Turtle. [SKOS Analytical Techniques vocabulary]( https://github.com/amds-ldeo/Vocabulary/blob/master/geochemistry/GeochemAnalyticalMethod.ttl)
+| Workflow | Source folder | Deploys to |
+|---|---|---|
+| [`process_geochemistry_vocab.yml`](.github/workflows/process_geochemistry_vocab.yml) | `geochemistry/` | `gh-pages:/docs/geochemistry/` |
+| [`process_etmaterials_vocab.yml`](.github/workflows/process_etmaterials_vocab.yml) | `ETmaterials/` | `gh-pages:/docs/ETmaterials/` |
+| [`process_instrumentall_vocab.yml`](.github/workflows/process_instrumentall_vocab.yml) | `instrumentAll/` | `gh-pages:/docs/instrumentAll/` |
+| [`process_instruments_vocab.yml`](.github/workflows/process_instruments_vocab.yml) | `instruments/` | `gh-pages:/docs/instruments/` |
+| [`publish_landing_page.yml`](.github/workflows/publish_landing_page.yml) | `docs/readme.md` | `gh-pages:/docs/readme.md` |
 
-### GeoXAnalyticalTechnique.ttl
-SKOS vocabualary, serialized using Turtle. Based on Geo-X spreadsheet from Manja Luzi (GFZ Potsdam), with some general categories added to fill out the hierarchy. 
-[GeoX Analytical Techniques vocabulary draft]( https://github.com/amds-ldeo/Vocabulary/blob/master/geochemistry/GeoXAnalyticalTechnique.ttl)
+All vocabulary workflows are manually dispatched (`workflow_dispatch`). The landing-page workflow runs automatically when `docs/readme.md` changes on `master`.
 
-## Extraterrestrial materials folder (ETmaterials)
+See [`AGENTS.md`](AGENTS.md) for maintainer/contributor/agent notes — adding a new vocabulary, running the pipeline locally without Docker, per-subdirectory caveats, and divergences from the upstream template.
 
-This folder contains development work for a vocabulary to classify types of meteorites and other extraterrestrial (ET) materials. Classes based on Meteorite Bulletin (MetBull) classes that were extracted into Mindat. Some MetBull classes are not included in Mindat and will be added. There are some lunar materials based on Apollo return samples, and links to a few terrestrial material classes that subsume the ET material.
+## Geochemistry
 
-### Extraterrestrial Materials classes
-Vocabulary of categories of meteorites and lunar materials. 
-- [HTML view of Extraterrestrial materials vocabulary]( https://amds-ldeo.github.io/Vocabulary/ETmaterials/html/ExtraterrestrialMaterialsMindat.html)
-- SKOS vocabualary, serialized using Turtle. [SKOS Extraterrestrial materials vocabulary]( https://github.com/amds-ldeo/Vocabulary/blob/master/ETmaterials/ExtraterrestrialMaterialsMindat.ttl)
+Vocabularies for analytical techniques in geochemistry and cosmochemistry.
 
-### Minerals
-Draft vocabulary for mineral species. Information pulled from Wikipedia, RRUFF, and MinDat.  Includes hierarchy from Strunz classes and Mindat mineral groups. 
-- [HTML view of Mineral vocabulary](https://geosamples.github.io/vocabularies/mineralSKOS.html).  This is a big file, takes awhile to load.
-- [SKOS Turtle file, Mineral vocabulary draft](https://github.com/GeoSamples/vocabularies/blob/main/vocabulary/mineralSKOS.ttl).  Draft is in the vocabularies 
-repo for geosamples.org. 
+### Geochemical analytical methods
+
+Vocabulary of analytical techniques for analyzing Earth, astronomic, and planetary materials.
+
+- [HTML view](https://amds-ldeo.github.io/Vocabulary/geochemistry/GeochemAnalyticalMethod.html)
+- [ARDC Research Vocabularies Australia landing page](https://vocabs.ardc.edu.au/viewById/650)
+- [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/geochemistry/GeochemAnalyticalMethod.ttl)
+
+### OneGeochemistry analytical techniques (Astromat v4)
+
+- [HTML view](https://amds-ldeo.github.io/Vocabulary/geochemistry/onegctechniquesastromatv4.html)
+- [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/geochemistry/onegctechniquesastromatv4.ttl)
+
+Earlier drafts (`GeoXAnalyticalTechnique.ttl`, `AnalyticalTechnique.ttl`, PoolParty v2/v3) are preserved under [`geochemistry/archive/`](geochemistry/archive).
+
+## Extraterrestrial materials (`ETmaterials/`)
+
+Vocabulary to classify types of meteorites and other extraterrestrial materials. Classes based on Meteorite Bulletin (MetBull) categories extracted into Mindat, extended with Apollo lunar materials and links to subsuming terrestrial material classes.
+
+- [HTML view](https://amds-ldeo.github.io/Vocabulary/ETmaterials/ExtraterrestrialMaterialsMindat.html)
+- [SKOS Turtle source](https://github.com/amds-ldeo/Vocabulary/blob/master/ETmaterials/ExtraterrestrialMaterialsMindat.ttl)
+
+## Instruments, parameters, and sampling (`instrumentAll/`, `instruments/`)
+
+Concept schemes compiled from SeaDataNet/NETMAR/NERC vocabularies (SDN device categories L22, SDN keyword types L19, SDN keyword categories L21, EDMED DCAT themes D01). Each ttl is rendered by anchoring the concept tree at the scheme whose `skos:hasTopConcept` entries align with the file's `skos:broader`/`narrower` roots (`SDNDEV/current` for most; `EDMED_DCAT_THEMES/current` for `Parameters`).
+
+- Measurement instruments — [HTML view](https://amds-ldeo.github.io/Vocabulary/instrumentAll/Instruments.html) · [source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/Instruments.ttl)
+- Numeric models — [HTML view](https://amds-ldeo.github.io/Vocabulary/instrumentAll/NumericModel.html) · [source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/NumericModel.ttl)
+- Parameters — [HTML view](https://amds-ldeo.github.io/Vocabulary/instrumentAll/Parameters.html) · [source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/Parameters.ttl)
+- Positioning systems — [HTML view](https://amds-ldeo.github.io/Vocabulary/instrumentAll/PositioningSystem.html) · [source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/PositioningSystem.ttl)
+- Sample collection instruments — [HTML view](https://amds-ldeo.github.io/Vocabulary/instrumentAll/SampleCollection.html) · [source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/SampleCollection.ttl)
+- Sample preparation instruments — [HTML view](https://amds-ldeo.github.io/Vocabulary/instrumentAll/SamplePreparation.html) · [source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/SamplePreparation.ttl)
+- Seismic sources — [HTML view](https://amds-ldeo.github.io/Vocabulary/instrumentAll/SeismicSource.html) · [source](https://github.com/amds-ldeo/Vocabulary/blob/master/instrumentAll/SeismicSource.ttl)
+- MMISW instrument models — [HTML view](https://amds-ldeo.github.io/Vocabulary/instruments/mmisw-models.html) · [source](https://github.com/amds-ldeo/Vocabulary/blob/master/instruments/mmisw-models.ttl)
+
+## Related vocabularies (external)
+
+- [Minerals vocabulary](https://geosamples.github.io/vocabularies/mineralSKOS.html) (hosted in `GeoSamples/vocabularies`).
+
+## Contributing
+
+See [`AGENTS.md`](AGENTS.md) for operational detail: how to add a vocabulary, how to verify changes locally without Docker, and what files not to touch. Pull requests against `master`; vocabulary workflows must be re-dispatched after merge to refresh the published HTML.


### PR DESCRIPTION
## Summary

Docs update for the state of the repo after the vocabularyTemplate port, per-subdirectory workflows, and the 10 live vocabulary pages.

### README.md
- Drop the pre-port narrative (pages-branch Jekyll pipeline, stale \`/geochemistry/html/...\` URLs, \`GeoXAnalyticalTechnique\` pointer).
- Start with a workflow→subdir→target-folder table.
- List all 10 published vocabularies with live \`gh-pages\` URLs at the new flat \`/docs/<subdir>/<slug>.html\` locations.
- Point maintainer detail at \`AGENTS.md\`.

### AGENTS.md (new)
- Vocabulary table: every slug + CURIE + added-prefix notes + anchor-concept notes per vocab.
- Option-A (no-Docker) and Option-B (Docker) local verification recipes, with the \`PYTHONIOENCODING=utf-8\` Windows workaround documented.
- Divergences from upstream \`vocabularyTemplate\` — the things to remember next time someone ports fixes in/out:
  - multi-subdir \`Dockerfile\` COPY layout
  - \`cache/\` gitignored rather than committed
  - \`.dockerignore\` with \`.github\` exception
  - per-subdir workflows using \`vocabdir\` input
  - \`publish_landing_page.yml\` with \`clean: false\`
  - \`sudo chown -R\` over \`docs/\` after the root-owned container run
- "Don't touch" list (\`.claude/\`, \`.idea/\`, \`.project\`, \`*-SMR-Samsung.*\`, pre-existing staged work).
- Known gaps: \`mmisw-models\` scheme lacks \`skos:prefLabel\` (cosmetic "ConceptScheme" title); local Option-A cp1252 workaround.

## Test plan

- [x] Spot-check every live URL in README.md resolves to a 200 (manual).
- [x] No broken internal links to \`docs/readme.md\`, \`AGENTS.md\`, workflow files, `action.yml`, \`Dockerfile\`.