### PR TITLE
Add process_all_vocabularies.yml — one-click rebuild orchestrator

### DIFF
--- a/.github/workflows/process_all_vocabularies.yml
+++ b/.github/workflows/process_all_vocabularies.yml
@@ -1,0 +1,34 @@
+# Orchestrator that runs every per-subdirectory vocabulary workflow in one click.
+#
+# Invokes the four process_*_vocab.yml workflows as reusable workflows
+# (workflow_call), chained via `needs:` so they run **sequentially**. Sequential
+# matters: each one deploys to the gh-pages branch and parallel pushes would
+# race (the JamesIves deploy action force-pushes by default).
+#
+# The individual process_<subdir>_vocab.yml workflows remain independently
+# dispatchable via the Actions tab; this one is a shortcut when you want to
+# rebuild everything after a wide source change.
+#
+# Manual dispatch only — triggered via the "Run workflow" button.
+
+name: Process all vocabularies
+on: [workflow_dispatch]
+
+permissions:
+  contents: write
+
+jobs:
+  geochemistry:
+    uses: ./.github/workflows/process_geochemistry_vocab.yml
+
+  etmaterials:
+    needs: geochemistry
+    uses: ./.github/workflows/process_etmaterials_vocab.yml
+
+  instrumentall:
+    needs: etmaterials
+    uses: ./.github/workflows/process_instrumentall_vocab.yml
+
+  instruments:
+    needs: instrumentall
+    uses: ./.github/workflows/process_instruments_vocab.yml

--- a/.github/workflows/process_etmaterials_vocab.yml
+++ b/.github/workflows/process_etmaterials_vocab.yml
@@ -4,7 +4,7 @@
 # Triggered manually via the GitHub Actions "Run workflow" button.
 
 name: Process ETmaterials vocabularies
-on: [workflow_dispatch]
+on: [workflow_dispatch, workflow_call]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/process_geochemistry_vocab.yml
+++ b/.github/workflows/process_geochemistry_vocab.yml
@@ -8,7 +8,7 @@
 # CURIEs must resolve via @prefix declarations inside the corresponding ttl file.
 
 name: Process geochemistry vocabularies
-on: [workflow_dispatch]
+on: [workflow_dispatch, workflow_call]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/process_instrumentall_vocab.yml
+++ b/.github/workflows/process_instrumentall_vocab.yml
@@ -12,7 +12,7 @@
 # (See PR #13 for analysis and rationale.)
 
 name: Process instrumentAll vocabularies
-on: [workflow_dispatch]
+on: [workflow_dispatch, workflow_call]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/process_instruments_vocab.yml
+++ b/.github/workflows/process_instruments_vocab.yml
@@ -10,7 +10,7 @@
 # no top concepts are declared, and the fallback honors subclass typing.
 
 name: Process instruments vocabularies
-on: [workflow_dispatch]
+on: [workflow_dispatch, workflow_call]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

One-click workflow that rebuilds every subdirectory's HTML by calling the four existing per-subdirectory workflows as **reusable workflows** (via \`workflow_call\`):

- \`process_geochemistry_vocab.yml\`
- \`process_etmaterials_vocab.yml\`
- \`process_instrumentall_vocab.yml\`
- \`process_instruments_vocab.yml\`

Chained with \`needs:\` so they run **sequentially**. Parallel would be faster, but each one deploys to \`gh-pages\` and parallel pushes would race (the JamesIves deploy action force-pushes by default, so a race loses one deploy's content).

## Impact on existing workflows

Each existing \`process_<subdir>_vocab.yml\` gains \`workflow_call\` in its \`on:\` list alongside \`workflow_dispatch\`. One-line change each, no behavioral change — individual subdirectories remain independently dispatchable via the Actions tab.

## Test plan

- [ ] After merge, dispatch \`Process all vocabularies\`; should spawn one top-level run with four chained child runs, each successful and deploying its own \`docs/<subdir>/\` slice.
- [ ] Sanity: \`Process geochemistry vocabularies\` (and the other three) still individually dispatchable.